### PR TITLE
feat: agregar configuración de despliegue para Render

### DIFF
--- a/Dockerfile.mysql
+++ b/Dockerfile.mysql
@@ -1,0 +1,16 @@
+FROM mysql:8.0
+
+# Configuración específica para MySQL en Render
+ENV MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
+ENV MYSQL_DATABASE=${MYSQL_DATABASE}
+ENV MYSQL_USER=${MYSQL_USER}
+ENV MYSQL_PASSWORD=${MYSQL_PASSWORD}
+
+# Configuraciones adicionales para producción
+COPY ./mysql-config.cnf /etc/mysql/conf.d/custom.cnf
+
+# Puerto por defecto de MySQL
+EXPOSE 3306
+
+# Comando de inicio
+CMD ["mysqld"]

--- a/RENDER_DEPLOYMENT.md
+++ b/RENDER_DEPLOYMENT.md
@@ -1,0 +1,155 @@
+# Despliegue en Render
+
+Esta guía te ayudará a desplegar tu aplicación Donaccion en Render usando el archivo `render.yaml` configurado.
+
+## Archivos Necesarios
+
+Asegúrate de tener estos archivos en tu repositorio:
+
+```
+monorepo-donaccion/
+├── render.yaml                    # Configuración principal de Render
+├── Dockerfile.mysql              # Dockerfile para MySQL
+├── mysql-config.cnf              # Configuración de MySQL
+├── backend/
+│   └── Dockerfile               # Dockerfile del backend (optimizado)
+├── frontend/
+│   ├── Dockerfile               # Dockerfile del frontend (optimizado)
+│   └── nginx.conf               # Configuración de Nginx
+└── RENDER_DEPLOYMENT.md         # Esta documentación
+```
+
+## Configuración en Render
+
+### 1. Conectar tu Repositorio
+
+1. Ve a [Render Dashboard](https://dashboard.render.com)
+2. Haz clic en "New +" → "Blueprint"
+3. Conecta tu repositorio de GitHub
+4. Render detectará automáticamente el archivo `render.yaml`
+
+### 2. Variables de Entorno
+
+Render configurará automáticamente estas variables:
+
+**Para MySQL:**
+- `MYSQL_ROOT_PASSWORD` (generada automáticamente)
+- `MYSQL_DATABASE=donaccion`
+- `MYSQL_USER=donaccion_user`
+- `MYSQL_PASSWORD` (generada automáticamente)
+
+**Para Backend:**
+- `SPRING_PROFILES_ACTIVE=production`
+- `SERVER_PORT=10000`
+- `SPRING_DATASOURCE_URL` (conectada automáticamente a MySQL)
+- `SPRING_DATASOURCE_USERNAME` (conectada automáticamente)
+- `SPRING_DATASOURCE_PASSWORD` (conectada automáticamente)
+
+**Para Frontend:**
+- `NODE_ENV=production`
+- `API_URL` (conectada automáticamente al backend)
+
+### 3. Despliegue
+
+1. Render detectará el archivo `render.yaml`
+2. Creará automáticamente 3 servicios:
+   - **MySQL Database** (servicio privado)
+   - **Backend API** (servicio web)
+   - **Frontend** (servicio web)
+
+## URLs de Acceso
+
+Una vez desplegado, tendrás:
+
+- **Frontend**: `https://frontend-donaccion.onrender.com`
+- **Backend API**: `https://backend-donaccion.onrender.com`
+- **Base de datos**: Solo accesible internamente
+
+## Verificación del Despliegue
+
+### Backend
+```bash
+# Health check
+curl https://backend-donaccion.onrender.com/health
+
+# API de prueba
+curl https://backend-donaccion.onrender.com/api/test
+```
+
+### Frontend
+- Visita `https://frontend-donaccion.onrender.com`
+- Debería cargar la aplicación Angular
+- Verifica que las llamadas a la API funcionen
+
+## Troubleshooting
+
+### Problemas Comunes
+
+#### 1. Backend no se conecta a la base de datos
+- **Causa**: El backend se inicia antes que MySQL
+- **Solución**: Render maneja esto automáticamente con `fromService`
+
+#### 2. Frontend no puede conectar al backend
+- **Causa**: URL de API incorrecta
+- **Solución**: Verificar que `API_URL` esté configurada correctamente
+
+#### 3. Error de CORS
+- **Causa**: Configuración de CORS en el backend
+- **Solución**: Asegúrate de que el backend permita el dominio del frontend
+
+### Logs y Debugging
+
+1. **Ver logs del backend:**
+   - Ve al dashboard de Render
+   - Selecciona el servicio backend
+   - Ve a la pestaña "Logs"
+
+2. **Ver logs del frontend:**
+   - Selecciona el servicio frontend
+   - Ve a la pestaña "Logs"
+
+3. **Ver logs de MySQL:**
+   - Selecciona el servicio MySQL
+   - Ve a la pestaña "Logs"
+
+## Costos
+
+**Plan Starter (Gratuito):**
+- MySQL: $0/mes (con limitaciones)
+- Backend: $0/mes (se duerme después de 15 min de inactividad)
+- Frontend: $0/mes (se duerme después de 15 min de inactividad)
+
+**Plan Standard (Recomendado para producción):**
+- MySQL: $7/mes
+- Backend: $7/mes
+- Frontend: $7/mes
+
+## Actualizaciones
+
+Para actualizar tu aplicación:
+
+1. Haz push a tu rama principal
+2. Render detectará automáticamente los cambios
+3. Reconstruirá y redesplegará los servicios
+
+## Notas Importantes
+
+- **Sleep Mode**: En el plan gratuito, los servicios se duermen después de 15 minutos de inactividad
+- **Cold Start**: El primer acceso después del sleep puede tardar 30-60 segundos
+- **Base de datos**: MySQL en el plan gratuito tiene limitaciones de almacenamiento
+- **Variables de entorno**: Se generan automáticamente, no necesitas configurarlas manualmente
+
+## Soporte
+
+Si tienes problemas:
+
+1. Revisa los logs en el dashboard de Render
+2. Verifica que todos los archivos estén en el repositorio
+3. Asegúrate de que el archivo `render.yaml` esté en la raíz del proyecto
+4. Contacta al soporte de Render si es necesario
+
+## Enlaces Útiles
+
+- [Documentación de Render](https://render.com/docs)
+- [Render Dashboard](https://dashboard.render.com)
+- [Configuración de Blueprint](https://render.com/docs/blueprint-spec)

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,16 +1,32 @@
 FROM eclipse-temurin:21-jdk AS build
 WORKDIR /app
 
+# Copiar archivos de Maven
 COPY .mvn/ .mvn/
 COPY mvnw pom.xml ./
+
+# Descargar dependencias
 RUN ./mvnw dependency:go-offline -B
 
+# Copiar código fuente
 COPY src ./src
 
+# Compilar la aplicación
 RUN ./mvnw clean package -DskipTests
 
+# Imagen de producción
 FROM eclipse-temurin:21-jre-alpine
 WORKDIR /opt
+
+# Copiar el JAR compilado
 COPY --from=build /app/target/*.jar app.jar
-EXPOSE 8080
-ENTRYPOINT ["java", "-jar", "app.jar"]
+
+# Configuraciones para Render
+ENV SPRING_PROFILES_ACTIVE=production
+ENV SERVER_PORT=10000
+
+# Exponer puerto (Render usa el puerto 10000)
+EXPOSE 10000
+
+# Comando de inicio con configuraciones JVM optimizadas
+ENTRYPOINT ["java", "-Xmx512m", "-Xms256m", "-jar", "app.jar"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,10 +1,32 @@
 FROM node:22-alpine AS build
 WORKDIR /app
+
+# Copiar archivos de dependencias
 COPY package*.json ./
+
+# Instalar dependencias
 RUN npm ci --include=dev
+
+# Copiar código fuente
 COPY . .
+
+# Configurar variables de entorno para producción
+ENV NODE_ENV=production
+
+# Construir la aplicación
 RUN npm run build --configuration=production
 
+# Imagen de producción con Nginx
 FROM nginx:alpine
+
+# Copiar archivos construidos
 COPY --from=build /app/dist/frontend /usr/share/nginx/html
+
+# Configuración de Nginx para SPA
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+# Exponer puerto 80
 EXPOSE 80
+
+# Comando de inicio
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,35 @@
+server {
+    listen 80;
+    server_name localhost;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Configuración para SPA (Single Page Application)
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Configuración para archivos estáticos
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # Configuración para archivos HTML
+    location ~* \.html$ {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        add_header Pragma "no-cache";
+        add_header Expires "0";
+    }
+
+    # Configuración de seguridad
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+
+    # Configuración de compresión
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_types text/plain text/css text/xml text/javascript application/javascript application/xml+rss application/json;
+}

--- a/mysql-config.cnf
+++ b/mysql-config.cnf
@@ -1,0 +1,21 @@
+[mysqld]
+# Configuración optimizada para Render
+innodb_buffer_pool_size = 128M
+innodb_log_file_size = 32M
+innodb_flush_log_at_trx_commit = 2
+innodb_flush_method = O_DIRECT
+
+# Configuraciones de conexión
+max_connections = 100
+wait_timeout = 28800
+interactive_timeout = 28800
+
+# Configuraciones de seguridad
+bind-address = 0.0.0.0
+skip-name-resolve = 1
+
+# Configuraciones de logging
+general_log = 0
+slow_query_log = 1
+slow_query_log_file = /var/log/mysql/slow.log
+long_query_time = 2

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,58 @@
+services:
+  # Base de datos MySQL
+  - type: pserv
+    name: mysql-donaccion
+    env: docker
+    dockerfilePath: ./Dockerfile.mysql
+    envVars:
+      - key: MYSQL_ROOT_PASSWORD
+        generateValue: true
+      - key: MYSQL_DATABASE
+        value: donaccion
+      - key: MYSQL_USER
+        value: donaccion_user
+      - key: MYSQL_PASSWORD
+        generateValue: true
+    plan: starter
+
+  # Backend Spring Boot
+  - type: web
+    name: backend-donaccion
+    env: docker
+    dockerfilePath: ./backend/Dockerfile
+    envVars:
+      - key: SPRING_PROFILES_ACTIVE
+        value: production
+      - key: SPRING_DATASOURCE_URL
+        fromService:
+          type: pserv
+          name: mysql-donaccion
+          property: connectionString
+      - key: SPRING_DATASOURCE_USERNAME
+        fromService:
+          type: pserv
+          name: mysql-donaccion
+          envVarKey: MYSQL_USER
+      - key: SPRING_DATASOURCE_PASSWORD
+        fromService:
+          type: pserv
+          name: mysql-donaccion
+          envVarKey: MYSQL_PASSWORD
+      - key: SERVER_PORT
+        value: 10000
+    plan: starter
+
+  # Frontend Angular
+  - type: web
+    name: frontend-donaccion
+    env: docker
+    dockerfilePath: ./frontend/Dockerfile
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: API_URL
+        fromService:
+          type: web
+          name: backend-donaccion
+          property: host
+    plan: starter


### PR DESCRIPTION
- Crear render.yaml con configuración de servicios (MySQL, backend, frontend)
- Agregar Dockerfile.mysql y mysql-config.cnf para base de datos
- Optimizar Dockerfiles del backend y frontend para producción
- Incluir configuración de Nginx para SPA Angular
- Documentar proceso de despliegue en RENDER_DEPLOYMENT.md

Los archivos de Render no afectan el entorno de desarrollo local.