### PR TITLE
fix: corregir Dockerfile para Maven sin .mvn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,12 @@ FROM eclipse-temurin:21-jdk AS build
 WORKDIR /app
 
 # Copiar archivos de Maven del backend
-COPY backend/.mvn/ .mvn/
-COPY backend/mvnw backend/pom.xml ./
+COPY backend/pom.xml ./
+COPY backend/mvnw ./
+# Dar permisos de ejecución al wrapper de Maven
+RUN chmod +x ./mvnw
+
+# Descargar dependencias
 RUN ./mvnw dependency:go-offline -B
 
 # Copiar código fuente del backend


### PR DESCRIPTION
- Remover dependencia de carpeta .mvn inexistente
- Agregar permisos de ejecución a mvnw
- Separar copia de archivos para mejor cache
- Solucionar error de build en Render