### PR TITLE
fix: usar imagen con Maven preinstalado

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # Dockerfile para el servicio principal (Backend)
-FROM eclipse-temurin:21-jdk AS build
+FROM maven:3.9.6-openjdk-21 AS build
 WORKDIR /app
 
 # Copiar archivos de Maven del backend
 COPY backend/pom.xml ./
 
-# Usar Maven directamente (más confiable que wrapper)
+# Descargar dependencias
 RUN mvn dependency:go-offline -B
 
 # Copiar código fuente del backend


### PR DESCRIPTION
- Cambiar de eclipse-temurin a maven:3.9.6-openjdk-21
- Solucionar error 'mvn: not found' en build
- Mantener Java 21 y optimizaciones de build
- Hacer build más confiable en Render