### PR TITLE
fix: configurar perfil dev sin base de datos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ WORKDIR /opt
 COPY --from=build /app/target/*.jar app.jar
 
 # Configuraciones para Render
-ENV SPRING_PROFILES_ACTIVE=production
+ENV SPRING_PROFILES_ACTIVE=dev
 ENV SERVER_PORT=10000
 
 # Exponer puerto (Render usa el puerto 10000)

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -1,0 +1,5 @@
+# Configuración para desarrollo sin base de datos
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration,org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
+
+# Configuración del servidor
+server.port=10000


### PR DESCRIPTION
- Crear application-dev.properties sin dependencias de BD
- Cambiar SPRING_PROFILES_ACTIVE a dev en Dockerfile
- Permitir que backend funcione sin MySQL
- Solucionar error de conexión a base de datos