### PR TITLE
Fix: Permitir acceso pÃºblico a actuator para healthcheck de Render y…

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -5,25 +5,6 @@ services:
     dockerfilePath: ./backend/Dockerfile
     dockerContext: ./backend
     plan: free
-    envVars:
-      - key: SPRING_DATASOURCE_URL
-        value: ${SPRING_DATASOURCE_URL}
-      - key: SPRING_DATASOURCE_USERNAME
-        value: ${SPRING_DATASOURCE_USERNAME}
-      - key: SPRING_DATASOURCE_PASSWORD
-        value: ${SPRING_DATASOURCE_PASSWORD}
-      - key: SPRING_JPA_HIBERNATE_DDL_AUTO
-        value: update
-      - key: SPRING_JPA_SHOW_SQL
-        value: false
-      - key: SPRING_JPA_PROPERTIES_HIBERNATE_DIALECT
-        value: org.hibernate.dialect.MySQL8Dialect
-      - key: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI
-        value: ${SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI}
-      - key: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_AUDIENCES
-        value: ${SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_AUDIENCES}
-      - key: CORS_ALLOWED_ORIGINS
-        value: ${CORS_ALLOWED_ORIGINS}
     healthCheckPath: /actuator/health
 
   - type: web


### PR DESCRIPTION
… simplificar render.yaml

- Permitir /actuator/** sin autenticaciÃ³n en SecurityConfig para que Render pueda verificar el healthcheck
- Remover variables de entorno de render.yaml para evitar sobrescritura en cada deploy
- Las variables ahora se gestionan manualmente desde el Dashboard de Render